### PR TITLE
Fix test for block time change from 2.62 to 2.12

### DIFF
--- a/test/unit/models/test_proposals.py
+++ b/test/unit/models/test_proposals.py
@@ -215,11 +215,11 @@ def test_proposal_is_expired(proposal):
     proposal.end_epoch = now - (60 * 60)  # expired one hour ago
     assert proposal.is_expired(superblockcycle=cycle) is False
 
-    # fudge factor + a 24-block cycle == an expiry window of 9086, so...
-    proposal.end_epoch = now - 9085
+    # fudge factor + a 24-block cycle == an expiry window of 8726, so...
+    proposal.end_epoch = now - 8725
     assert proposal.is_expired(superblockcycle=cycle) is False
 
-    proposal.end_epoch = now - 9087
+    proposal.end_epoch = now - 8727
     assert proposal.is_expired(superblockcycle=cycle) is True
 
 

--- a/test/unit/test_terracoiny_things.py
+++ b/test/unit/test_terracoiny_things.py
@@ -136,5 +136,5 @@ def test_blocks_to_seconds():
     precision = Decimal('0.001')
     assert Decimal(terracoinlib.blocks_to_seconds(0)) == Decimal(0.0)
     assert Decimal(terracoinlib.blocks_to_seconds(2)).quantize(precision) \
-        == Decimal(314.4).quantize(precision)
-    assert int(terracoinlib.blocks_to_seconds(16616)) == 2612035
+        == Decimal(254.4).quantize(precision)
+    assert int(terracoinlib.blocks_to_seconds(16616)) == 2113555


### PR DESCRIPTION
This fixes the test on block time calculations since the code changes from 2.62 per block to 2.12.

6 more tests to go, mostly because of the wallet verification now